### PR TITLE
[DCRDEV-320]: バインド設定を修正、arm64で動作するようにplatformを変更

### DIFF
--- a/demo_docker/docker-compose.yaml
+++ b/demo_docker/docker-compose.yaml
@@ -12,16 +12,16 @@ services:
     <<: *build
     volumes:
     - type: bind
-      source: Client0/settings.ini
+      source: bind/Client0/settings.ini
       target: /settings.ini
     - type: bind
-      source: Client0/sample_data.csv
+      source: bind/Client0/sample_data.csv
       target: /data.csv
     - type: bind
-      source: Client0
+      source: bind/Client0
       target: /result
     - type: bind
-      source: Client0/.logs
+      source: bind/Client0/.logs
       target: /.logs
     command:
       - /bin/bash
@@ -32,16 +32,16 @@ services:
     <<: *build
     volumes:
     - type: bind
-      source: Client1/settings.ini
+      source: bind/Client1/settings.ini
       target: /settings.ini
     - type: bind
-      source: Client1/sample_data.csv
+      source: bind/Client1/sample_data.csv
       target: /data.csv
     - type: bind
-      source: Client1
+      source: bind/Client1
       target: /result
     - type: bind
-      source: Client1/.logs
+      source: bind/Client1/.logs
       target: /.logs
     command:
       - /bin/bash

--- a/demo_docker/docker-compose.yaml
+++ b/demo_docker/docker-compose.yaml
@@ -10,6 +10,7 @@ x-build: &build
 services:
   firm_demo0:
     <<: *build
+    platform: linux/amd64
     volumes:
     - type: bind
       source: bind/Client0/settings.ini
@@ -30,6 +31,7 @@ services:
 
   firm_demo1:
     <<: *build
+    platform: linux/amd64
     volumes:
     - type: bind
       source: bind/Client1/settings.ini


### PR DESCRIPTION
## 概要
- bind するディレクトリの指定が誤っていたため修正しました
- arm64 で動作するように platform を指定しました


## 備考
platformを変更したイメージのビルド時に発生したissue
https://github.com/docker/for-mac/issues/7255